### PR TITLE
Fix the index page `post-summary`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site
+.sass-cache
+.jekyll-metadata
+

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ layout: default
             {% if post.summary %}
               {{ post.summary }}
             {% else %}
-              {{ post.excerpt }}
+              {{ post.excerpt | remove: '<p>' | remove: '</p>' }}
             {% endif %}
           </p>
         </a>


### PR DESCRIPTION
When a post does not define a `summary`, the `excerpt` will be used. However, since `excerpt` is already wrapped in `p` tags, it will not work well with the existing `p` tag.
